### PR TITLE
feat(): dockerise the setup so users can just invoke `docker-compose up`

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1.4
+
+FROM node:lts-buster-slim
+
+WORKDIR /usr/client
+
+COPY client /usr/client/
+RUN npm install --legacy-peer-deps 
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1.4
+
+FROM node:lts-buster-slim
+
+WORKDIR /usr/server
+
+COPY server /usr/server/
+RUN npm install --legacy-peer-deps
+
+EXPOSE 5000
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ git clone https://github.com/cloudsmith-io/cloudsmith-migration-tool.git
 cd cloudsmith-migration-tool
 ```
 
+## Docker
+
+If you have docker (and docker-compose installed), you can bring up the stack like so:
+
+```shell
+docker-compose up
+```
+
+Then navigate to [http://localhost:3333](http://localhost:3333)
+
 ## Running the project
 
 Open two terminals/shells:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.7'
+
+services:
+  server:
+    build: 
+      context: .
+      dockerfile: Dockerfile.server
+    ports:
+      - "5000:5000"
+
+  client:
+    build:
+      context: .
+      dockerfile: Dockerfile.client
+    ports:
+      - "3000:3000"
+    depends_on:
+      - server


### PR DESCRIPTION
Hey

It's nice to just be able to use docker to run the container stack. I've add a simple docker stack that will let a user start the application that bit more easily if they have docker on their machine.

Users can just start the stack like so:

```shell
cd ~/cloudsmith-migration-tool
docker-compose up
```

![image](https://github.com/cloudsmith-io/cloudsmith-migration-tool/assets/104829833/5eadffe3-9df1-43b9-af30-de3da7a545a7)

The logs look something like this:

```
➜  cloudsmith-migration-tool git:(main) ✗ docker-compose up
[+] Building 121.8s (11/11) FINISHED                                                                                                                                                         docker:desktop-linux
 => [client internal] load build definition from Dockerfile.client                                                                                                                                           0.0s
 => => transferring dockerfile: 222B                                                                                                                                                                         0.0s
 => [client internal] load .dockerignore                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                              0.0s
 => [client] resolve image config for docker.io/docker/dockerfile:1.4                                                                                                                                        0.9s
 => CACHED [client] docker-image://docker.io/docker/dockerfile:1.4@sha256:9ba7531bd80fb0a858632727cf7a112fbfd19b17e94c4e84ced81e24ef1a0dbc                                                                   0.0s
 => [client internal] load metadata for docker.io/library/node:lts-buster-slim                                                                                                                               1.2s
 => CACHED [client 1/4] FROM docker.io/library/node:lts-buster-slim@sha256:8c9059926fd1c99feb8236d81553cd0fcb1d843019923c846c97558bb1ebbdd4                                                                  0.0s
 => [client internal] load build context                                                                                                                                                                     0.0s
 => => transferring context: 86.55kB                                                                                                                                                                         0.0s
 => [client 2/4] WORKDIR /usr/client                                                                                                                                                                         0.0s
 => [client 3/4] COPY client /usr/client/                                                                                                                                                                    0.0s
 => [client 4/4] RUN npm install --legacy-peer-deps                                                                                                                                                        108.2s
 => [client] exporting to image                                                                                                                                                                             11.1s
 => => exporting layers                                                                                                                                                                                     11.1s
 => => writing image sha256:40cf9d14d4240c7e99be2602178835f8e8ceaa8a7fb3938c99ef54ffe1d1cbf8                                                                                                                 0.0s
 => => naming to docker.io/library/cloudsmith-migration-tool-client                                                                                                                                          0.0s
[+] Running 2/1
 ✔ Container cloudsmith-migration-tool-server-1  Recreated                                                                                                                                                   1.3s
 ✔ Container cloudsmith-migration-tool-client-1  Created                                                                                                                                                     0.1s
Attaching to client-1, server-1
server-1  | Server is running on port 5000
client-1  |
client-1  | > client@0.1.0 start
client-1  | > react-scripts start
client-1  |
client-1  | (node:36) [DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE] DeprecationWarning: 'onAfterSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
client-1  | (Use `node --trace-deprecation ...` to show where the warning was created)
client-1  | (node:36) [DEP_WEBPACK_DEV_SERVER_ON_BEFORE_SETUP_MIDDLEWARE] DeprecationWarning: 'onBeforeSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
client-1  | Starting the development server...
client-1  |
client-1  | Compiled successfully!
client-1  |
client-1  | You can now view client in the browser.
client-1  |
client-1  |   Local:            http://localhost:3000
client-1  |   On Your Network:  http://172.31.0.3:3000
client-1  |
client-1  | Note that the development build is not optimized.
client-1  | To create a production build, use npm run build.
client-1  |
client-1  | webpack compiled successfully
client-1  | Compiling...
client-1  | Compiled successfully!
client-1  | webpack compiled successfully
```